### PR TITLE
HP-2693: added alias for `4.16.0` version of `nikic/php-parser` package to prevent conflict with `phpunit/phpunit: ^12.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     ],
     "require": {
         "hiqdev/php-data-mapper": "dev-master",
-        "ocramius/generated-hydrator": "^4.6.0",
+        "hiqdev/generated-hydrator": "^4.6.0",
         "nikic/php-parser": "5.6.1 as 4.16.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,8 @@
     ],
     "require": {
         "hiqdev/php-data-mapper": "dev-master",
-        "ocramius/generated-hydrator": "^4.6.0"
+        "ocramius/generated-hydrator": "^4.6.0",
+        "nikic/php-parser": "5.6.1 as 4.16.0"
     },
     "require-dev": {
         "hiqdev/hidev": "dev-master",

--- a/tests/unit/BaseHydratorTestCase.php
+++ b/tests/unit/BaseHydratorTestCase.php
@@ -11,8 +11,10 @@
 namespace hiqdev\yii\DataMapper\tests\unit;
 
 use Laminas\Hydrator\HydratorInterface;
+use PHPUnit\Framework\TestCase;
+use yii\helpers\Yii;
 
-abstract class BaseHydratorTest extends \PHPUnit\Framework\TestCase
+abstract class BaseHydratorTestCase extends TestCase
 {
     protected function getHydrator(): HydratorInterface
     {
@@ -21,6 +23,6 @@ abstract class BaseHydratorTest extends \PHPUnit\Framework\TestCase
 
     protected function getContainer()
     {
-        return class_exists('Yii') ? \Yii::$container : \yii\helpers\Yii::getContainer();
+        return class_exists('Yii') ? \Yii::$container : Yii::getContainer();
     }
 }

--- a/tests/unit/BaseRepositoryTestCase.php
+++ b/tests/unit/BaseRepositoryTestCase.php
@@ -10,15 +10,19 @@
 
 namespace hiqdev\yii\DataMapper\tests\unit;
 
+use Exception;
+use hiqdev\DataMapper\Repository\BaseRepository;
 use hiqdev\DataMapper\Repository\EntityManagerInterface;
+use PHPUnit\Framework\TestCase;
+use yii\helpers\Yii;
 
-abstract class BaseRepositoryTest extends \PHPUnit\Framework\TestCase
+abstract class BaseRepositoryTestCase extends TestCase
 {
     /**
-     * @template T of \hiqdev\DataMapper\Repository\BaseRepository
+     * @template T of BaseRepository
      * @psalm-param class-string<T> $entityClass
      * @return T
-     * @throws \Exception
+     * @throws Exception
      */
     protected function getRepository(string $entityClass)
     {
@@ -32,6 +36,6 @@ abstract class BaseRepositoryTest extends \PHPUnit\Framework\TestCase
 
     protected function getContainer()
     {
-        return class_exists('Yii') ? \Yii::$container : \yii\helpers\Yii::getContainer();
+        return class_exists('Yii') ? \Yii::$container : Yii::getContainer();
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated project dependencies: replaced a generated-hydrator package and added a PHP parsing library for compatibility.

- **Tests**
  - Streamlined unit test base classes and imports to simplify test setup.

- **Refactor**
  - Renamed test base classes for clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->