### PR TITLE
Hp 2693 switch ocramius packages to hiqdev version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     ],
     "require": {
         "hiqdev/php-data-mapper": "dev-master",
-        "ocramius/generated-hydrator": "^4.6.0"
+        "hiqdev/generated-hydrator": "dev-master"
     },
     "require-dev": {
         "hiqdev/hidev": "dev-master",
@@ -73,6 +73,10 @@
         {
             "type": "composer",
             "url": "https://asset-packagist.org"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/hiqdev/GeneratedHydrator"
         }
     ]
 }

--- a/composer.json
+++ b/composer.json
@@ -73,10 +73,6 @@
         {
             "type": "composer",
             "url": "https://asset-packagist.org"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/hiqdev/GeneratedHydrator"
         }
     ]
 }

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     ],
     "require": {
         "hiqdev/php-data-mapper": "dev-master",
-        "hiqdev/generated-hydrator": "dev-master"
+        "hiqdev/generated-hydrator": "^4.7.0"
     },
     "require-dev": {
         "hiqdev/hidev": "dev-master",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Updated the underlying hydrator dependency to a maintained alternative and bumped to a newer compatible version. Aligns with ecosystem changes, improves maintainability and supply-chain continuity. No user-facing changes or configuration updates required; behavior should remain the same. Ensures compatibility with upcoming releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->